### PR TITLE
Git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Pasta de assets
+assets/

--- a/ToDo.csproj
+++ b/ToDo.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="assets\" />
+  </ItemGroup>
+
 </Project>

--- a/assets/todolist.txt
+++ b/assets/todolist.txt
@@ -1,1 +1,0 @@
-6Tp27YLDugFijmPr83xsE0yZVLaJh4/15Je3ND+bGNY=


### PR DESCRIPTION
Ignorando arquivos criados em Assets, pois a pasta é destinada a armazenar configurações locais

Atualiza .gitignore e estrutura do projeto

- Adiciona a pasta `assets/` ao `.gitignore`.
- Inclui referência à pasta `assets\` no `ToDo.csproj`.
- Remove uma linha do `todolist.txt` que continha um identificador.